### PR TITLE
Fixes CI Error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:latest as build-stage
+FROM node:15.14 as build-stage
 WORKDIR /app
 COPY package.json ./
 COPY yarn.lock ./


### PR DESCRIPTION
Der Fehler lag darin, dass node-gyp noch nicht mit node 16 (vor drei Tagen released) kompatibel ist. Habe die Version jetzt auf 15.14 gepinnt, somit sollte das problem nichtmehr auftauchen﻿
